### PR TITLE
make the state file an optional feature; fix some comments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ before_install:
   - bash download_serf
   - bundle install --path .bundle
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.0
 branches:

--- a/lib/serfx/utils/async_job.rb
+++ b/lib/serfx/utils/async_job.rb
@@ -100,7 +100,7 @@ module Serfx
 
       # kill an already running task
       #
-      # @param sig [String] kill signal that will sent to the backgroun process
+      # @param sig [String] kill signal that will sent to the background process
       # @return [TrueClass,FalseClass] true on success, false on failure
       def kill(sig = 'KILL')
         if running?
@@ -116,7 +116,7 @@ module Serfx
         end
       end
 
-      # obtain current state information about the task as json
+      # obtain current state information about the task as JSON
       #
       # @return [String] JSON string representing current state of the task
       def state_info
@@ -134,7 +134,7 @@ module Serfx
         JSON.parse(state_info)
       end
 
-      # delete the statefile of a finished task
+      # delete the state file of a finished task
       #
       # @return [String] 'success' if the task is reaped, 'failed' otherwise
       def reap
@@ -211,10 +211,10 @@ module Serfx
         state_file.nil? ? false : File.exist?(state_file)
       end
 
-      # writes a hash as json in the state_file
+      # writes a hash as JSON in the state_file
       # @param [Hash] state represented as a hash, to be written
       def write_state(state)
-        unless state_file.nil?
+        if state_file
           File.open(state_file, 'w') do |f|
             f.write(JSON.generate(state))
           end

--- a/lib/serfx/utils/async_job.rb
+++ b/lib/serfx/utils/async_job.rb
@@ -8,20 +8,20 @@ module Serfx
     # in progress. Due to this, long running tasks should not be
     # invoked as serf handler directly.
     #
-    # AsyncJob helps buildng serf handlers that involve long running commands.
+    # AsyncJob helps building serf handlers that involve long running commands.
     # It starts the command in background, allowing handler code to
     # return immediately. It does double fork where the first child process is
     # detached (attached to init as parent process) and and the target long
     # running task is spawned as a second child process. This allows the first
     # child  process to wait and reap the output of actual long running task.
     #
-    # The first child process updates a state file before spawing
-    # the long ranning task(state='invoking'), during the lon running task
+    # The first child process updates a state file before spawning
+    # the long ranning task(state='invoking'), during the long running task
     # execution (state='running') and after the spawned process' return
     # (state='finished'). This state file provides a convenient way to
     # query the current state of an AsyncJob.
     #
-    # AsyncJob porvide four methods to manage jobs. AsyncJob#start will
+    # AsyncJob provides four methods to manage jobs. AsyncJob#start will
     # start the task. Once started, AyncJob#state_info can be used to check
     # whether the job is still running or finished. One started a job can be
     # either in 'running' state or in 'finished' state. AsyncJob#reap
@@ -29,6 +29,10 @@ module Serfx
     # An AsyncJob can be killed, if its in running state, using the
     # AsyncJob#kill method. A new AyncJob can not be started unless previous
     # AsyncJob with same name/state file is reaped.
+    #
+    # If the state file is nil, no state will be persisted for the job.
+    # As such, AsyncJob#state_info, AsyncJob#kill, and AsyncJob#reap will
+    # be a NO-OP.
     #
     # Following is an example of writing a serf handler using AsyncJob.
     #
@@ -86,7 +90,7 @@ module Serfx
       # @option opts [Symbol] :environment a hash containing environment variables
       # @option opts [Symbol] :cwd a string (directory path) containing current directory of the command
       def initialize(opts = {})
-        @state_file = opts[:state] || fail(ArgumentError, 'Specify state file')
+        @state_file = opts[:state]
         @command = opts[:command]
         @stdout_file = opts[:stdout] || File::NULL
         @stderr_file = opts[:stderr] || File::NULL
@@ -204,14 +208,16 @@ module Serfx
       #
       # @return [TrueClass, FalseClass] true if the task exists, else false
       def exists?
-        File.exist?(state_file)
+        state_file.nil? ? false : File.exist?(state_file)
       end
 
       # writes a hash as json in the state_file
       # @param [Hash] state represented as a hash, to be written
       def write_state(state)
-        File.open(state_file, 'w') do |f|
-          f.write(JSON.generate(state))
+        unless state_file.nil?
+          File.open(state_file, 'w') do |f|
+            f.write(JSON.generate(state))
+          end
         end
       end
     end


### PR DESCRIPTION
The state file is great for tasks where you plan on coming back later to verify the state of the job. However, if you want to have a handler for a fire-and-forget event it becomes a bit troublesome. If you don't reap the state file, subsequent events will silently fail. Because it is a fire-and-forget event, the failures are then widespread and silent.

I didn't see any assertions against the state file itself, so let me know if there's anything you'd like me to enhance there.

Lastly, fixed some typos in some of the comments.

To note: beyond a compilation check, `ruby -c`, this hasn't been thoroughly tested. I don't have an environment locally to do so, just yet.