### PR TITLE
(bug) AsyncHandler allow query to be regex

### DIFF
--- a/download_serf
+++ b/download_serf
@@ -1,5 +1,5 @@
 #!/bin/bash
 mkdir serf_binaries
 cd serf_binaries
-wget -c https://dl.bintray.com/mitchellh/serf/0.6.0_linux_amd64.zip
-unzip 0.6.0_linux_amd64.zip
+wget -c https://releases.hashicorp.com/serf/0.7.0/serf_0.7.0_linux_amd64.zip
+unzip serf_0.7.0_linux_amd64.zip

--- a/lib/serfx/utils/handler.rb
+++ b/lib/serfx/utils/handler.rb
@@ -69,7 +69,7 @@ module Serfx
         event = SerfEvent.new
         callbacks[event.type.downcase.to_sym].each do |cbk|
           if cbk.name
-            cbk.block.call(event) if event.name === cbk.name
+            cbk.block.call(event) if cbk.name === event.name
           else
             cbk.block.call(event)
           end

--- a/spec/serfx/client_spec.rb
+++ b/spec/serfx/client_spec.rb
@@ -133,16 +133,16 @@ describe Serfx do
     keys = @conn.list_keys.body['Keys'].keys
     expect(keys).to include('QHOYjmYlxSCBhdfiolhtDQ==')
     @conn.install_key('Ih6cZqutM33tMdoFo1iNyw==')
-    sleep 2
+    sleep 5
     keys = @conn.list_keys.body['Keys'].keys
     expect(keys).to include('Ih6cZqutM33tMdoFo1iNyw==')
-    sleep 2
+    sleep 5
     @conn.use_key('Ih6cZqutM33tMdoFo1iNyw==')
     new_keys = @conn.list_keys.body['Keys'].keys
-    sleep 2
+    sleep 5
     expect(new_keys.first).to eq('Ih6cZqutM33tMdoFo1iNyw==')
     @conn.remove_key('QHOYjmYlxSCBhdfiolhtDQ==')
-    sleep 2
+    sleep 5
     final_keys = @conn.list_keys.body['Keys'].keys
     expect(final_keys.first).to_not include('QHOYjmYlxSCBhdfiolhtDQ==')
   end

--- a/spec/serfx/handler_spec.rb
+++ b/spec/serfx/handler_spec.rb
@@ -15,7 +15,25 @@ describe Serfx::Utils::Handler do
     end
     ENV['SERF_EVENT'] = 'query'
     ENV['SERF_QUERY_NAME'] = 'foo'
-    STDIN.should_receive(:read_nonblock).and_return('yeah')
+    expect(STDIN).to receive(:read_nonblock).and_return('yeah')
+    CustomHandler.run
+    expect(CustomHandler.state[:payload]).to eq('yeah')
+  end
+
+  it 'accepts event payload as regex' do
+    class CustomHandler
+      extend Serfx::Utils::Handler
+      @@state = {}
+      def self.state
+        @@state
+      end
+      on :query, /foo:\w+/ do |event|
+        @@state[:payload] = event.payload
+      end
+    end
+    ENV['SERF_EVENT'] = 'query'
+    ENV['SERF_QUERY_NAME'] = 'foo:bar'
+    expect(STDIN).to receive(:read_nonblock).and_return('yeah')
     CustomHandler.run
     expect(CustomHandler.state[:payload]).to eq('yeah')
   end


### PR DESCRIPTION
regex has to be left hand operation. or === method returns true for regex, not for strings. This was designed to work, 
```ruby
on :query, /foo/ do |event|
end
```
but due to keeping the event.name in the right side, === returned false. This PR fixes that