### PR TITLE
Add check to see if Error in the response header is nil

### DIFF
--- a/lib/serfx/connection.rb
+++ b/lib/serfx/connection.rb
@@ -107,7 +107,7 @@ module Serfx
     #
     # @param header [Hash] RPC response header as hash
     def check_rpc_error!(header)
-      fail RPCError, header['Error'] unless header['Error'].empty?
+      fail RPCError, header['Error'] unless header['Error'].nil? || header['Error'].empty?
     end
 
     # read data from the tcp socket. and convert it to a [Response] object


### PR DESCRIPTION
Similar case to PagerDuty/serfx#2, it appears that Serf 0.7.x also can pass a header with a nil Error.